### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Included in the Thunderhead SDK's AndroidManifest.xml are the following permissi
 ```
 *Note:* 
 - The `SYSTEM_ALERT_WINDOW` permission is only needed for Admin mode builds. In your setup you can add this as a flavor specific permission to avoid having to show this as a permission change to your Play Store users.
-- You can remove this permission in User mode builds by using: 
+- You can remove this permission in User mode builds by adding the following to your manifest: 
     ```xml 
         <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
     ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ buildscript {
 }
 ```
 ####  `build.gradle` examples
-Example of the **top-level** `build.gradle` file after integration:
+
+#####  **Thunderhead ONE** `build.gradle` examples:
+
+###### Example of the **top-level** `build.gradle` file after integration:
 ``` gradle
 buildscript {
     repositories {
@@ -101,7 +104,7 @@ allprojects {
 }
 ```
 
-Example of the **app-level** `build.gradle` file after integration:
+###### Example of the **app-level** `build.gradle` file after integration:
 ``` gradle
 apply plugin: 'com.android.application'
 apply plugin: 'com.thunderhead.android.aspectj-ext'
@@ -129,12 +132,78 @@ aspectj {
     ajcArgs << '-Xlint:ignore'
 }
 
-dependencies {
-    implementation (group: 'com.thunderhead.android', name: 'one-sdk', version: '2.21.1') {
-      exclude group: 'com.squareup.retrofit'
-    }
-    implementation fileTree(include: ['*.jar'], dir: 'libs')    
+dependencies {     
+	implementation ("com.thunderhead.android:one-sdk:2.21.1") {
+	    exclude group: 'com.squareup.retrofit'
+	}
 }
+
+repositories {
+    maven {
+       url 'https://thunderhead.mycloudrepo.io/public/repositories/one-sdk-android'
+    }
+}
+
+```
+
+#####  **Salesforce Interaction Studio** `build.gradle` examples:
+
+###### Example of the **top-level** `build.gradle` file after integration:
+``` gradle
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.thunderhead.android:android-gradle-plugin-aspectj:4.0.1'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        mavenCentral()
+        google()
+    }
+}
+```
+
+###### Example of the **app-level** `build.gradle` file after integration:
+``` gradle
+apply plugin: 'com.android.application'
+apply plugin: 'com.thunderhead.android.aspectj-ext'
+
+
+android {
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
+
+    defaultConfig {
+        applicationId "com.thunderhead.android.demo"
+        minSdkVersion 16
+        targetSdkVersion 27
+        versionCode 1
+        versionName "1.0"
+
+        renderscriptTargetApi 20
+        renderscriptSupportModeEnabled true
+    }
+
+}
+
+aspectj {
+    includeAspectsFromJar 'is_sdk'
+    ajcArgs << '-Xlint:ignore'
+}
+
+dependencies {     
+	implementation ("com.thunderhead.android:is-sdk:2.21.1") {
+	    exclude group: 'com.squareup.retrofit'
+	}
+}
+
 repositories {
     maven {
        url 'https://thunderhead.mycloudrepo.io/public/repositories/one-sdk-android'

--- a/README.md
+++ b/README.md
@@ -222,7 +222,12 @@ Included in the Thunderhead SDK's AndroidManifest.xml are the following permissi
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 ```
-*Note:* The `SYSTEM_ALERT_WINDOW` permission is only needed for Admin mode builds. In your setup you can add this as a flavor specific permission to avoid having to show this as a permission change to your Play Store users.
+*Note:* 
+- The `SYSTEM_ALERT_WINDOW` permission is only needed for Admin mode builds. In your setup you can add this as a flavor specific permission to avoid having to show this as a permission change to your Play Store users.
+- You can remove this permission in User mode builds by using: 
+    ```xml 
+        <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
+    ```
 
 ### Subclass your `Application` Class
 If you haven’t done so already, you will need to subclass your `Application` class in order to be able to initialize the SDK. If you are just creating an `Application` subclass please remember to define it in your app manifest.
@@ -260,7 +265,9 @@ To use the framework in Admin mode, change the ONE mode to `ADMIN_MODE`, as foll
 ``` java 
 one.init(siteKey, touchpointURI, apiKey, sharedSecret, userId, OneModes.ADMIN_MODE, hostName);
 ```
-*Note:* If you are running in Admin mode on Android 6.0+, you will need to enable the “draw over other apps” permission via your OS settings. 
+*Note:* 
+- If you are running in Admin mode on Android 6.0+, you will need to enable the “draw over other apps” permission via your OS settings. 
+- If you have added both User and Admin mode support under the same app build, please note that the app will need to be terminated and restarted when switching from one mode to the other.
 
 **You have now successfully integrated the codeless Thunderhead SDK for Android.**
 
@@ -726,6 +733,18 @@ One one = One.getInstance(getApplicationContext());
 one.sendPushToken("DUI03F379S1UUIDA6DADF8DFQPZ");
 
 ```
+
+*Note:* 
+- The following permissions are used and will be merged into your app's manifest:
+```xml 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+```
+- You can remove these permissions by adding the following to your manifest: 
+    ```xml 
+        <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" tools:node="remove" />
+        <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" tools:node="remove" />
+    ```
 
 ### Send a location object
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ repositories {
 ``` gradle 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -86,8 +86,8 @@ buildscript {
 ``` gradle
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -97,9 +97,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
-        google()
     }
 }
 ```
@@ -152,8 +152,8 @@ repositories {
 ``` gradle
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -163,9 +163,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
-        google()
     }
 }
 ```


### PR DESCRIPTION
- Readme updates based on THX-34397 and THX-34953
- Fixed example `build.gradle`
- Moved `google()` above `jcenter()`